### PR TITLE
Add Loot Table to Upper Block in 1.14

### DIFF
--- a/src/main/resources/data/uppers/loot_tables/blocks/upper.json
+++ b/src/main/resources/data/uppers/loot_tables/blocks/upper.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "uppers:upper"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Without this, the Upper block drops nothing. 