### PR TITLE
Lie about the up/down direction, to be more compatible with vanilla c…

### DIFF
--- a/src/main/java/uppers/tiles/InventoryCodeHooksTweaked.java
+++ b/src/main/java/uppers/tiles/InventoryCodeHooksTweaked.java
@@ -27,7 +27,8 @@ public class InventoryCodeHooksTweaked
     @Nullable
     public static Boolean extractHook(IUpper dest)
     {
-    	return getItemHandler(dest, Direction.DOWN).map(itemHandlerResult -> {
+        // Lie, real direction is Down & Up, but Down & Down is more compatible with vanilla containers.
+        return getItemHandler(dest, Direction.DOWN, Direction.DOWN).map(itemHandlerResult -> {
 
         IItemHandler handler = itemHandlerResult.getKey();
 
@@ -153,12 +154,15 @@ public class InventoryCodeHooksTweaked
         return stack;
     }
 
-    private static LazyOptional<Pair<IItemHandler, Object>> getItemHandler(IUpper upper, Direction upperFacing)
+    private static LazyOptional<Pair<IItemHandler, Object>> getItemHandler(IUpper upper, Direction upperFacing) {
+        return getItemHandler(upper, upperFacing, upperFacing.getOpposite());
+    }
+    private static LazyOptional<Pair<IItemHandler, Object>> getItemHandler(IUpper upper, Direction upperFacing, Direction invetoryFacing)
     {
         double x = upper.getXPos() + (double) upperFacing.getXOffset();
         double y = upper.getYPos() + (double) upperFacing.getYOffset();
         double z = upper.getZPos() + (double) upperFacing.getZOffset();
-        return getItemHandler(upper.getWorld(), x, y, z, upperFacing.getOpposite());
+        return getItemHandler(upper.getWorld(), x, y, z, invetoryFacing);
     }
 
     private static boolean isFull(IItemHandler itemHandler)

--- a/src/main/java/uppers/tiles/UpperTileEntity.java
+++ b/src/main/java/uppers/tiles/UpperTileEntity.java
@@ -167,14 +167,16 @@ public class UpperTileEntity  extends LockableLootTileEntity implements IUpper, 
 		if (iinventory == null)
 			return false;
 		else {
-			Direction direction = ((Direction) getBlockState().get(UpperBlock.FACING)).getOpposite();
-			if (isInventoryFull(iinventory, direction))
+			Direction blockDirection = getBlockState().get(UpperBlock.FACING);
+			// Lie, when the block Direction is up, the real direction is Down, but Up works better with vanila containers.
+			Direction itemDirection = blockDirection == Direction.UP ? blockDirection : blockDirection.getOpposite();
+			if (isInventoryFull(iinventory, itemDirection))
 				return false;
 			else {
 				for (int i = 0; i < getSizeInventory(); ++i) {
 					if (!getStackInSlot(i).isEmpty()) {
 						ItemStack itemstack = getStackInSlot(i).copy();
-						ItemStack itemstack1 = putStackInInventoryAllSlots(this, iinventory, decrStackSize(i, 1), direction);
+						ItemStack itemstack1 = putStackInInventoryAllSlots(this, iinventory, decrStackSize(i, 1), itemDirection);
 						if (itemstack1.isEmpty()) {
 							iinventory.markDirty();
 							return true;
@@ -210,6 +212,7 @@ public class UpperTileEntity  extends LockableLootTileEntity implements IUpper, 
 			return ret;
 		IInventory iinventory = getSourceInventory(upper);
 		if (iinventory != null) {
+			// Lie, real direction is Up, but Down is more compatible with vanilla containers.
 			Direction direction = Direction.DOWN;
 	         return isInventoryEmpty(iinventory, direction) ? false : inventoryChecked(iinventory, direction).anyMatch((inventoryIn) -> {
 	             return pullItemFromSlot(upper, iinventory, inventoryIn, direction);


### PR DESCRIPTION
Solves the incompability with vanlia containers, mentioned in #4.
Lies and says up instead of down, and down instead of up.