### PR TITLE
Move Uppers to redstone tab

### DIFF
--- a/src/main/java/uppers/ModBlocks.java
+++ b/src/main/java/uppers/ModBlocks.java
@@ -11,6 +11,7 @@ import net.minecraft.block.material.MaterialColor;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.text.ITextComponent;
@@ -32,7 +33,7 @@ public class ModBlocks {
 
 	public static void init() {
 		UPPER = new UpperBlock(Block.Properties.create(Material.IRON, MaterialColor.STONE).hardnessAndResistance(3.0F, 4.8F).sound(SoundType.METAL));
-		UPPER_ITEM = new BlockItem(UPPER, new Item.Properties().group(Uppers.TAB)) {
+		UPPER_ITEM = new BlockItem(UPPER, new Item.Properties().group(ItemGroup.REDSTONE)) {
 			@Override
 			@OnlyIn(Dist.CLIENT)
 			   public void addInformation(ItemStack stack, @Nullable World worldIn, List<ITextComponent> tooltip, ITooltipFlag flagIn) {

--- a/src/main/java/uppers/Uppers.java
+++ b/src/main/java/uppers/Uppers.java
@@ -21,13 +21,6 @@ public class Uppers {
 		MinecraftForge.EVENT_BUS.register(this);
 	}
 
-	public static ItemGroup TAB = new ItemGroup(Reference.MOD_ID) {
-		@Override
-		public ItemStack createIcon() {
-			return new ItemStack(ModBlocks.UPPER_ITEM);
-		}
-	};
-
 	private void setup(final FMLCommonSetupEvent event) {}
 
 	private void doClientStuff(final FMLClientSetupEvent event) {}


### PR DESCRIPTION
The Upper was so lonely in its upper-tab on the 2nd page, moved it to the redstone tab with the other hoppers.